### PR TITLE
🐛 #39 'lodash/clamp' failed to resolve error when start project with limepaly lib

### DIFF
--- a/packages/limeplay-core/src/hooks/useTimeline.ts
+++ b/packages/limeplay-core/src/hooks/useTimeline.ts
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import clamp from 'lodash/clamp';
+import { clamp } from 'lodash';
 import { useStateRef } from '../utils';
 import { useLimeplay } from '../components';
 


### PR DESCRIPTION
Resolve the problem: 
BREAKING CHANGE: The request 'lodash/clamp' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '.mjs' file, or a '.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.