### PR TITLE
fix: vercel response headers and redirects for LLM mdx

### DIFF
--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -11,18 +11,6 @@ const config = {
   images: {
     unoptimized: true,
   },
-  headers() {
-    return [
-      {
-        source: "/docs/(.+)\\.mdx$",
-        headers: [{ key: "Content-Type", value: "text/markdown" }],
-      },
-      {
-        source: "/llms.mdx/(.*)",
-        headers: [{ key: "Content-Type", value: "text/markdown" }],
-      },
-    ]
-  },
 }
 
 export default withMDX(config)

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -14,7 +14,7 @@ const config = {
   headers() {
     return [
       {
-        source: "^/docs/(.+)\\.mdx$",
+        source: "/docs/(.+)\\.mdx$",
         headers: [{ key: "Content-Type", value: "text/markdown" }],
       },
       {

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -11,11 +11,15 @@ const config = {
   images: {
     unoptimized: true,
   },
-  async rewrites() {
+  headers() {
     return [
       {
-        source: "/docs/:path*.mdx",
-        destination: "/llms.mdx/:path*",
+        source: "^/docs/(.+)\\.mdx$",
+        headers: [{ key: "Content-Type", value: "text/markdown" }],
+      },
+      {
+        source: "/llms.mdx/(.*)",
+        headers: [{ key: "Content-Type", value: "text/markdown" }],
       },
     ]
   },

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -2,12 +2,22 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
+      "source": "^/docs/(.+)\\.mdx$",
+      "destination": "/llms.mdx/$1.mdx"
+    },
+    {
       "source": "^/docs",
       "destination": "/docs/quick-start"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/llms.mdx/(.*)",
+      "headers": [{ "key": "Content-Type", "value": "text/markdown" }]
     },
     {
       "source": "^/docs/(.+)\\.mdx$",
-      "destination": "/llms.mdx/$1.mdx"
+      "headers": [{ "key": "Content-Type", "value": "text/markdown" }]
     }
   ],
   "bunVersion": "1.2.19"

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -2,22 +2,12 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
-      "source": "^/docs/(.+)\\.mdx$",
-      "destination": "/llms.mdx/$1"
-    },
-    {
       "source": "^/docs",
       "destination": "/docs/quick-start"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/llms.mdx/(.*)",
-      "headers": [{ "key": "Content-Type", "value": "text/markdown" }]
     },
     {
       "source": "^/docs/(.+)\\.mdx$",
-      "headers": [{ "key": "Content-Type", "value": "text/markdown" }]
+      "destination": "/llms.mdx/$1.mdx"
     }
   ],
   "bunVersion": "1.2.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated server routing to stop using framework-level rewrites and to adjust how .mdx content URLs are mapped and served.
  * Normalized content slugs so trailing .mdx is handled consistently during requests and static route generation.
  * Removed prior header attachment behavior for certain routes and updated routing rules to deliver the intended MDX destinations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->