### PR TITLE
feat: media session API and siemap fixes

### DIFF
--- a/apps/www/app/(home)/layout.tsx
+++ b/apps/www/app/(home)/layout.tsx
@@ -10,9 +10,9 @@ export default function RootLayout({
   return (
     <main
       className={`
-          light w-dvw scrollbar-gutter-auto overscroll-contain bg-linear-to-br from-white to-neutral-200
-          md:scrollbar-gutter-stable
-        `}
+        light w-dvw scrollbar-gutter-auto overscroll-contain bg-linear-to-br from-white to-neutral-200
+        md:scrollbar-gutter-stable
+      `}
     >
       <VideoBackground />
       <Header />

--- a/apps/www/app/(home)/layout.tsx
+++ b/apps/www/app/(home)/layout.tsx
@@ -1,5 +1,3 @@
-import Script from "next/script"
-
 import { Footer } from "@/components/footer"
 import { Header } from "@/components/header"
 import { VideoBackground } from "@/components/video-background"
@@ -10,24 +8,16 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <>
-      {process.env.NODE_ENV === "development" && (
-        <Script
-          crossOrigin="anonymous"
-          src="//unpkg.com/react-scan/dist/auto.global.js"
-        />
-      )}
-      <main
-        className={`
+    <main
+      className={`
           light w-dvw scrollbar-gutter-auto overscroll-contain bg-linear-to-br from-white to-neutral-200
           md:scrollbar-gutter-stable
         `}
-      >
-        <VideoBackground />
-        <Header />
-        {children}
-        <Footer />
-      </main>
-    </>
+    >
+      <VideoBackground />
+      <Header />
+      {children}
+      <Footer />
+    </main>
   )
 }

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -7,6 +7,7 @@ import { UserJotProvider } from "@userjot/next"
 import { Analytics } from "@vercel/analytics/react"
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { Inter } from "next/font/google"
+import Script from "next/script"
 
 import { JsonLd } from "@/components/json-ld"
 import {
@@ -84,6 +85,12 @@ export default function Layout({ children }: { children: ReactNode }) {
     <html className={inter.className} lang="en" suppressHydrationWarning>
       <head>
         <UserJotProvider projectId="cmjs634l4043b15ldylgedgwi" />
+        {process.env.NODE_ENV === "development" && (
+          <Script
+            crossOrigin="anonymous"
+            src="//unpkg.com/react-scan/dist/auto.global.js"
+          />
+        )}
       </head>
       <body className="antialiased">
         <JsonLd />

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -89,6 +89,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <Script
             crossOrigin="anonymous"
             src="//unpkg.com/react-scan/dist/auto.global.js"
+            strategy="beforeInteractive"
           />
         )}
       </head>

--- a/apps/www/content/docs/blocks/audio-player.mdx
+++ b/apps/www/content/docs/blocks/audio-player.mdx
@@ -86,6 +86,7 @@ The audio block includes an opinionated default resolver for `src` and `playback
 - Previous, play/pause, next, volume, mute, repeat, and shuffle controls.
 - Playback URL resolution for direct `src` values or `playbackUrls.primary` endpoints.
 - Automatic skip/reload behavior for recoverable load and playback failures.
+- Browser Media Session metadata, playback state, position, and media-key handlers.
 - Shared `source` and `loading` contract used by all source-driven blocks.
 
 ## Notes
@@ -93,6 +94,7 @@ The audio block includes an opinionated default resolver for `src` and `playback
 - `AudioPlayer` does not ship with bundled tracks. Pass a playlist from your app.
 - Use `duration` in milliseconds when you want stable duration labels before metadata loads.
 - Do not pass `mediaProps.src`; pass `source` instead.
+- Media Session metadata is derived from the active track title, artist, album, and poster.
 - For the full block loading model, see [Usage](/docs/usage).
 
 ## API Reference

--- a/apps/www/content/docs/blocks/video-player.mdx
+++ b/apps/www/content/docs/blocks/video-player.mdx
@@ -93,6 +93,7 @@ Use `loading.resolveSource` when your app needs signed URLs, token refresh, or s
 - Timeline scrubbing with buffered progress feedback.
 - Volume, mute, captions, playback rate, and picture-in-picture controls.
 - Shaka-backed playback for HLS, DASH, and DRM-capable streams.
+- Browser Media Session metadata, playback state, position, and media-key handlers.
 - Shared `source` and `loading` contract used by all source-driven blocks.
 
 ## Notes
@@ -100,6 +101,7 @@ Use `loading.resolveSource` when your app needs signed URLs, token refresh, or s
 - `VideoPlayer` renders a video element internally. You do not need an `as` prop.
 - Pass `mediaProps` for native video options like `muted`, `playsInline`, or `autoPlay`.
 - Do not pass `mediaProps.src`; pass `source` instead.
+- Media Session metadata is derived from the active asset `title`, `description`, and `poster`.
 - For the full block loading model, see [Usage](/docs/usage).
 
 ## API Reference

--- a/apps/www/content/docs/hooks/index.mdx
+++ b/apps/www/content/docs/hooks/index.mdx
@@ -30,6 +30,7 @@ Standalone hooks that don't require feature registration:
 | Hook                                                             | Description                                 |
 | ---------------------------------------------------------------- | ------------------------------------------- |
 | [`use-seek`](/docs/hooks/use-seek)                               | Seek by offset (±N seconds)                 |
+| [`use-media-session`](/docs/hooks/use-media-session)             | Sync browser Media Session metadata and controls |
 | [`use-controls-visibility`](/docs/hooks/use-controls-visibility) | Auto-hide controls based on player activity |
 | [`use-idle`](/docs/hooks/use-idle)                               | Detect user inactivity                      |
 | [`use-interval`](/docs/hooks/use-interval)                       | `setInterval` with auto-cleanup             |

--- a/apps/www/content/docs/hooks/meta.json
+++ b/apps/www/content/docs/hooks/meta.json
@@ -11,6 +11,7 @@
     "use-playlist",
     "use-playback-rate",
     "use-picture-in-picture",
+    "use-media-session",
     "use-captions",
     "use-seek",
     "use-controls-visibility",

--- a/apps/www/content/docs/hooks/use-media-session.mdx
+++ b/apps/www/content/docs/hooks/use-media-session.mdx
@@ -1,0 +1,189 @@
+---
+title: use-media-session
+description: Utility hook for synchronizing browser Media Session metadata, playback state, position, and action handlers.
+---
+
+## Installation
+
+```npm
+npx shadcn add @limeplay/use-media-session
+```
+
+## Feature Registration
+
+`use-media-session` is a utility hook, not a media feature. It does not need to
+be registered in `createMediaKit`.
+
+Use it inside a client component that can read your current media state:
+
+```tsx title="components/player/media-session.tsx"
+"use client"
+
+import * as React from "react"
+
+import { useMediaSession } from "@/hooks/limeplay/use-media-session"
+
+export function MediaSessionController() {
+  const mediaSession = useMediaSession()
+
+  React.useEffect(() => {
+    mediaSession.setMetadata({
+      artist: "Creator",
+      artwork: [{ sizes: "512x512", src: "/poster.jpg" }],
+      title: "Current asset",
+    })
+
+    return () => mediaSession.clearMetadata()
+  }, [mediaSession])
+
+  return null
+}
+```
+
+## Store
+
+`useMediaSession` does not create a store slice. It wraps
+`navigator.mediaSession` and no-ops safely when the browser does not support the
+API.
+
+### State
+
+| Field       | Type      | Description                                            |
+| ----------- | --------- | ------------------------------------------------------ |
+| `supported` | `boolean` | Whether `navigator.mediaSession` is available.         |
+| Metadata    | Browser   | Stored on `navigator.mediaSession.metadata`.           |
+| Position    | Browser   | Stored through `navigator.mediaSession.setPositionState`. |
+
+### Actions
+
+| Method                               | Description                                                        |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| `setMetadata(metadata)`              | Sets browser media metadata using `MediaMetadata`.                  |
+| `clearMetadata()`                    | Clears browser media metadata.                                     |
+| `setPlaybackState(state)`            | Sets browser playback state to `none`, `paused`, or `playing`.      |
+| `setPositionState(state)`            | Sets duration, playback rate, and position when values are valid.   |
+| `clearPositionState()`               | Clears browser position state.                                     |
+| `setActionHandler(action, handler)`  | Registers a browser media action handler and returns a cleanup.     |
+
+## Sync Hook
+
+Use `useMediaSessionSync` when a component can derive the current metadata,
+playback state, position, and handlers from existing player stores.
+
+```tsx title="components/player/media-session.tsx"
+import {
+  getMediaSessionPlaybackState,
+  getMediaSessionPositionState,
+  useMediaSessionActionHandlers,
+  useMediaSessionSync,
+} from "@/hooks/limeplay/use-media-session"
+
+interface Asset {
+  creator?: string
+  poster?: string
+  title?: string
+}
+
+interface CustomMediaSessionControllerProps {
+  asset: Asset | null
+  currentTime: number
+  duration: number
+  onPause: () => void
+  onPlay: () => Promise<void>
+  onSeek: (time: number) => void
+  playbackRate: number
+  status: string
+}
+
+function CustomMediaSessionController({
+  asset,
+  currentTime,
+  duration,
+  onPause,
+  onPlay,
+  onSeek,
+  playbackRate,
+  status,
+}: CustomMediaSessionControllerProps) {
+  const active = Boolean(asset)
+  const actions = useMediaSessionActionHandlers({
+    getCurrentTime: () => currentTime,
+    onPause,
+    onPlay,
+    onSeek,
+  })
+
+  useMediaSessionSync({
+    actions,
+    active,
+    metadata: asset
+      ? {
+          artist: asset.creator,
+          artwork: asset.poster ? [{ src: asset.poster }] : [],
+          title: asset.title,
+        }
+      : null,
+    playbackState: getMediaSessionPlaybackState({
+      active,
+      status,
+    }),
+    position: getMediaSessionPositionState({
+      active,
+      currentTime,
+      duration,
+      playbackRate,
+    }),
+  })
+
+  return null
+}
+```
+
+## Action Handlers
+
+`useMediaSessionActionHandlers` builds the common media action map used by the
+default blocks.
+
+| Action                        | Option                            | Description                                      |
+| ----------------------------- | --------------------------------- | ------------------------------------------------ |
+| `play`                        | `onPlay`                          | Starts playback.                                 |
+| `pause`                       | `onPause`                         | Pauses playback.                                 |
+| `seekto`                      | `onSeek`                          | Seeks to the requested absolute media time.      |
+| `seekbackward` / `seekforward` | `getCurrentTime`, `onSeek`        | Seeks relative to the current media time.        |
+| `nexttrack`                   | `canGoNext`, `onNextTrack`        | Moves to the next playlist item when available.  |
+| `previoustrack`               | `canGoPrevious`, `onPreviousTrack` | Moves to the previous playlist item when available. |
+| `enterpictureinpicture`       | `canEnterPictureInPicture`, `onEnterPictureInPicture` | Lets supported browsers request PiP from Media Session. |
+| `skipad`                      | `onSkipAd`                        | Handles ad-skip requests when provided.          |
+| `stop`                        | `onStop`                          | Handles stop requests when provided.             |
+
+## Events
+
+`use-media-session` does not emit Limeplay media events.
+
+| Event | Payload | When |
+| ----- | ------- | ---- |
+| None  | —       | Browser Media Session callbacks call the handlers you register. |
+
+## Browser Behavior
+
+Media Session support varies by browser and action. Unsupported browsers and
+unsupported actions no-op safely. The `enterpictureinpicture` action is mainly a
+browser integration hook for automatic or browser-initiated Picture-in-Picture;
+it is not guaranteed to appear as a visible operating-system media control.
+
+## API Reference
+
+<AutoTypeTable
+  path="./registry/default/hooks/use-media-session.ts"
+  name="UseMediaSessionReturn"
+/>
+
+<AutoTypeTable
+  path="./registry/default/hooks/use-media-session.ts"
+  name="UseMediaSessionSyncOptions"
+/>
+
+<AutoTypeTable
+  path="./registry/default/hooks/use-media-session.ts"
+  name="UseMediaSessionActionHandlersOptions"
+/>

--- a/apps/www/content/docs/hooks/use-media-session.mdx
+++ b/apps/www/content/docs/hooks/use-media-session.mdx
@@ -48,30 +48,37 @@ API.
 
 ### State
 
-| Field       | Type      | Description                                            |
-| ----------- | --------- | ------------------------------------------------------ |
-| `supported` | `boolean` | Whether `navigator.mediaSession` is available.         |
-| Metadata    | Browser   | Stored on `navigator.mediaSession.metadata`.           |
+| Field       | Type      | Description                                               |
+| ----------- | --------- | --------------------------------------------------------- |
+| `supported` | `boolean` | Whether `navigator.mediaSession` is available.            |
+| Metadata    | Browser   | Stored on `navigator.mediaSession.metadata`.              |
 | Position    | Browser   | Stored through `navigator.mediaSession.setPositionState`. |
 
 ### Actions
 
-| Method                               | Description                                                        |
-| ------------------------------------ | ------------------------------------------------------------------ |
-| `setMetadata(metadata)`              | Sets browser media metadata using `MediaMetadata`.                  |
-| `clearMetadata()`                    | Clears browser media metadata.                                     |
-| `setPlaybackState(state)`            | Sets browser playback state to `none`, `paused`, or `playing`.      |
-| `setPositionState(state)`            | Sets duration, playback rate, and position when values are valid.   |
-| `clearPositionState()`               | Clears browser position state.                                     |
-| `setActionHandler(action, handler)`  | Registers a browser media action handler and returns a cleanup.     |
+| Method                              | Description                                                       |
+| ----------------------------------- | ----------------------------------------------------------------- |
+| `setMetadata(metadata)`             | Sets browser media metadata using `MediaMetadata`.                |
+| `clearMetadata()`                   | Clears browser media metadata.                                    |
+| `setPlaybackState(state)`           | Sets browser playback state to `none`, `paused`, or `playing`.    |
+| `setPositionState(state)`           | Sets duration, playback rate, and position when values are valid. |
+| `clearPositionState()`              | Clears browser position state.                                    |
+| `setActionHandler(action, handler)` | Registers a browser media action handler and returns a cleanup.   |
 
 ## Sync Hook
 
 Use `useMediaSessionSync` when a component can derive the current metadata,
 playback state, position, and handlers from existing player stores.
+Pass playback `status` to `getMediaSessionPlaybackState` so loading and buffering
+are reported as paused while the current position remains explicitly published.
+This prevents the platform from falling back to an independently advancing
+media-element clock. Guard `onPlay` with `canStartMediaSessionPlayback` so
+platform controls can retry loading or buffering media, but cannot start before
+initialization or from an unrecovered error state.
 
 ```tsx title="components/player/media-session.tsx"
 import {
+  canStartMediaSessionPlayback,
   getMediaSessionPlaybackState,
   getMediaSessionPositionState,
   useMediaSessionActionHandlers,
@@ -109,7 +116,11 @@ function CustomMediaSessionController({
   const actions = useMediaSessionActionHandlers({
     getCurrentTime: () => currentTime,
     onPause,
-    onPlay,
+    onPlay: () => {
+      if (!canStartMediaSessionPlayback(status)) return
+
+      return onPlay()
+    },
     onSeek,
   })
 
@@ -144,24 +155,24 @@ function CustomMediaSessionController({
 `useMediaSessionActionHandlers` builds the common media action map used by the
 default blocks.
 
-| Action                        | Option                            | Description                                      |
-| ----------------------------- | --------------------------------- | ------------------------------------------------ |
-| `play`                        | `onPlay`                          | Starts playback.                                 |
-| `pause`                       | `onPause`                         | Pauses playback.                                 |
-| `seekto`                      | `onSeek`                          | Seeks to the requested absolute media time.      |
-| `seekbackward` / `seekforward` | `getCurrentTime`, `onSeek`        | Seeks relative to the current media time.        |
-| `nexttrack`                   | `canGoNext`, `onNextTrack`        | Moves to the next playlist item when available.  |
-| `previoustrack`               | `canGoPrevious`, `onPreviousTrack` | Moves to the previous playlist item when available. |
-| `enterpictureinpicture`       | `canEnterPictureInPicture`, `onEnterPictureInPicture` | Lets supported browsers request PiP from Media Session. |
-| `skipad`                      | `onSkipAd`                        | Handles ad-skip requests when provided.          |
-| `stop`                        | `onStop`                          | Handles stop requests when provided.             |
+| Action                         | Option                                                | Description                                             |
+| ------------------------------ | ----------------------------------------------------- | ------------------------------------------------------- |
+| `play`                         | `onPlay`                                              | Starts playback.                                        |
+| `pause`                        | `onPause`                                             | Pauses playback.                                        |
+| `seekto`                       | `onSeek`                                              | Seeks to the requested absolute media time.             |
+| `seekbackward` / `seekforward` | `getCurrentTime`, `onSeek`                            | Seeks relative to the current media time.               |
+| `nexttrack`                    | `canGoNext`, `onNextTrack`                            | Moves to the next playlist item when available.         |
+| `previoustrack`                | `canGoPrevious`, `onPreviousTrack`                    | Moves to the previous playlist item when available.     |
+| `enterpictureinpicture`        | `canEnterPictureInPicture`, `onEnterPictureInPicture` | Lets supported browsers request PiP from Media Session. |
+| `skipad`                       | `onSkipAd`                                            | Handles ad-skip requests when provided.                 |
+| `stop`                         | `onStop`                                              | Handles stop requests when provided.                    |
 
 ## Events
 
 `use-media-session` does not emit Limeplay media events.
 
-| Event | Payload | When |
-| ----- | ------- | ---- |
+| Event | Payload | When                                                            |
+| ----- | ------- | --------------------------------------------------------------- |
 | None  | —       | Browser Media Session callbacks call the handlers you register. |
 
 ## Browser Behavior

--- a/apps/www/registry/collection/registry-blocks.ts
+++ b/apps/www/registry/collection/registry-blocks.ts
@@ -58,6 +58,10 @@ export const blocks: Registry["items"] = [
         type: "registry:component",
       },
       {
+        path: `${VIDEO_PLAYER_SRC_URL}/components/media-session-controller.tsx`,
+        type: "registry:component",
+      },
+      {
         path: `${VIDEO_PLAYER_SRC_URL}/components/button.tsx`,
         type: "registry:component",
       },
@@ -133,6 +137,7 @@ export const blocks: Registry["items"] = [
       "use-playlist",
       "use-asset",
       "use-media",
+      "use-media-session",
       "use-controls-visibility",
       "use-playback-source",
     ],
@@ -187,6 +192,10 @@ export const blocks: Registry["items"] = [
         type: "registry:component",
       },
       {
+        path: "blocks/audio-player/components/media-session-controller.tsx",
+        type: "registry:component",
+      },
+      {
         path: "blocks/audio-player/components/track-info.tsx",
         type: "registry:component",
       },
@@ -237,6 +246,7 @@ export const blocks: Registry["items"] = [
       "use-asset",
       "use-media",
       "use-playback-source",
+      "use-media-session",
       "limeplay-logo",
       "utils",
     ],

--- a/apps/www/registry/collection/registry-hooks.ts
+++ b/apps/www/registry/collection/registry-hooks.ts
@@ -17,6 +17,17 @@ export const hooks: Registry["items"] = [
     type: "registry:hook",
   },
   {
+    files: [
+      {
+        path: "hooks/use-media-session.ts",
+        target: `${TARGET_BASE_PATH}/use-media-session.ts`,
+        type: "registry:hook",
+      },
+    ],
+    name: "use-media-session",
+    type: "registry:hook",
+  },
+  {
     dependencies: ["lodash.clamp", "zustand"],
     devDependencies: ["@types/lodash.clamp"],
     files: [

--- a/apps/www/registry/default/blocks/audio-player/components/fixed-timeline-control.tsx
+++ b/apps/www/registry/default/blocks/audio-player/components/fixed-timeline-control.tsx
@@ -42,10 +42,8 @@ export function TimelineControl() {
         <TimelineSlider.Thumb
           className={cn(
             "absolute top-1/2 size-0 -translate-y-1/2 rounded-full bg-rose-600!",
-            `
-              transition-[height,width]
-              group-hover/timeline:size-4
-            `
+            "transition-[height,width] duration-150 ease-in-out",
+            "group-hover/timeline:size-4"
           )}
         />
 
@@ -56,6 +54,12 @@ export function TimelineControl() {
             group-hover/timeline:opacity-100
           `}
           showWithHover
+          style={
+            {
+              "--lp-timeline-thumb-left":
+                "clamp(calc((5ch + 1rem) / 2), var(--lp-timeline-thumb-position), calc(100% - calc((5ch + 1rem) / 2)))",
+            } as unknown as React.CSSProperties
+          }
         >
           <HoverTime />
         </TimelineSlider.Thumb>

--- a/apps/www/registry/default/blocks/audio-player/components/media-session-controller.tsx
+++ b/apps/www/registry/default/blocks/audio-player/components/media-session-controller.tsx
@@ -3,18 +3,19 @@
 import * as React from "react"
 
 import type { AudioPlayerAsset } from "@/registry/default/blocks/audio-player/player"
-import type { PlaylistStore } from "@/registry/default/hooks/use-playlist"
 
 import { getAudioAssetMetadata } from "@/registry/default/blocks/audio-player/components/audio-source"
 import { useMediaApi } from "@/registry/default/blocks/audio-player/lib/media-kit"
+import { useAsset, useAssetStore } from "@/registry/default/hooks/use-asset"
 import {
-  AssetSourceType,
-  useAsset,
-  useAssetStore,
-} from "@/registry/default/hooks/use-asset"
-import {
+  canMoveToNextMediaSessionTrack,
+  canMoveToPreviousMediaSessionTrack,
+  canStartMediaSessionPlayback,
+  getMediaSessionCurrentTime,
+  getMediaSessionMetadataValue,
   getMediaSessionPlaybackState,
   getMediaSessionPositionState,
+  isMediaSessionPlaylistSource,
   useMediaSessionActionHandlers,
   useMediaSessionSync,
 } from "@/registry/default/hooks/use-media-session"
@@ -23,14 +24,14 @@ import { useTimelineStore } from "@/registry/default/hooks/use-timeline"
 
 export function AudioMediaSessionController() {
   const mediaApi = useMediaApi()
-  const { currentItem, hasNext, hasPrevious } = useAsset<AudioPlayerAsset>()
+  const { currentItem } = useAsset<AudioPlayerAsset>()
   const currentTime = useTimelineStore((state) => state.currentTime)
   const duration = useTimelineStore((state) => state.duration)
   const sourceType = useAssetStore((state) => state.sourceType)
   const status = usePlaybackStore((state) => state.status)
   const asset = currentItem?.properties ?? null
   const active = asset !== null
-  const playlistSource = isPlaylistSource(sourceType)
+  const playlistSource = isMediaSessionPlaylistSource(sourceType)
 
   const metadata = React.useMemo(
     () => (asset ? getAudioMediaSessionMetadata(asset) : null),
@@ -46,12 +47,12 @@ export function AudioMediaSessionController() {
     [active, currentTime, duration]
   )
   const actions = useMediaSessionActionHandlers({
-    canGoNext: playlistSource && hasNext,
-    canGoPrevious: playlistSource && hasPrevious,
+    canGoNext: playlistSource,
+    canGoPrevious: playlistSource,
     getCurrentTime: () => {
       const state = mediaApi.getState()
 
-      return getCurrentTimelineTime({
+      return getMediaSessionCurrentTime({
         currentTime: state.timeline.currentTime,
         isLive: state.timeline.isLive,
         mediaElement: state.media.mediaElement,
@@ -64,17 +65,29 @@ export function AudioMediaSessionController() {
     },
     onNextTrack: () => {
       const state = mediaApi.getState()
-      if (canMoveToNextTrack(state.asset.sourceType, state.playlist)) {
+      if (
+        canMoveToNextMediaSessionTrack(state.asset.sourceType, state.playlist)
+      ) {
         state.playlist.next()
       }
     },
     onPause: () => {
       mediaApi.getState().playback.pause()
     },
-    onPlay: () => mediaApi.getState().playback.play(),
+    onPlay: () => {
+      const state = mediaApi.getState()
+      if (!canStartMediaSessionPlayback(state.playback.status)) return
+
+      return state.playback.play()
+    },
     onPreviousTrack: () => {
       const state = mediaApi.getState()
-      if (canMoveToPreviousTrack(state.asset.sourceType, state.playlist)) {
+      if (
+        canMoveToPreviousMediaSessionTrack(
+          state.asset.sourceType,
+          state.playlist
+        )
+      ) {
         state.playlist.previous()
       }
     },
@@ -94,75 +107,16 @@ export function AudioMediaSessionController() {
   return null
 }
 
-function canMoveToNextTrack(
-  sourceType: AssetSourceType | null,
-  playlist: PlaylistStore["playlist"]
-): boolean {
-  return isPlaylistSource(sourceType) && hasNextPlaylistItem(playlist)
-}
-
-function canMoveToPreviousTrack(
-  sourceType: AssetSourceType | null,
-  playlist: PlaylistStore["playlist"]
-): boolean {
-  return isPlaylistSource(sourceType) && hasPreviousPlaylistItem(playlist)
-}
-
-function firstNonEmpty(
-  ...values: (null | number | string | undefined)[]
-): string | undefined {
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return String(value)
-    }
-
-    if (typeof value !== "string") continue
-
-    const trimmed = value.trim()
-    if (trimmed) return trimmed
-  }
-
-  return undefined
-}
-
 function getAudioMediaSessionMetadata(
   asset: AudioPlayerAsset
 ): MediaMetadataInit {
   const metadata = getAudioAssetMetadata(asset)
-  const poster = firstNonEmpty(metadata.poster, asset.poster)
+  const poster = getMediaSessionMetadataValue(metadata.poster, asset.poster)
 
   return {
-    album: firstNonEmpty(asset.albumName),
-    artist: firstNonEmpty(asset.artistName, metadata.subtitle),
+    album: getMediaSessionMetadataValue(asset.albumName),
+    artist: getMediaSessionMetadataValue(asset.artistName),
     artwork: poster ? [{ sizes: "512x512", src: poster }] : [],
     title: metadata.title,
   }
-}
-
-function getCurrentTimelineTime({
-  currentTime,
-  isLive,
-  mediaElement,
-}: {
-  currentTime: number
-  isLive: boolean
-  mediaElement: HTMLMediaElement | null
-}): number {
-  return isLive && mediaElement ? mediaElement.currentTime : currentTime
-}
-
-function hasNextPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
-  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
-
-  return playlist.getNextIndex() !== -1
-}
-
-function hasPreviousPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
-  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
-
-  return playlist.getPreviousIndex() !== -1
-}
-
-function isPlaylistSource(sourceType: AssetSourceType | null): boolean {
-  return sourceType === AssetSourceType.Playlist
 }

--- a/apps/www/registry/default/blocks/audio-player/components/media-session-controller.tsx
+++ b/apps/www/registry/default/blocks/audio-player/components/media-session-controller.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import * as React from "react"
+
+import type { AudioPlayerAsset } from "@/registry/default/blocks/audio-player/player"
+import type { PlaylistStore } from "@/registry/default/hooks/use-playlist"
+
+import { getAudioAssetMetadata } from "@/registry/default/blocks/audio-player/components/audio-source"
+import { useMediaApi } from "@/registry/default/blocks/audio-player/lib/media-kit"
+import {
+  AssetSourceType,
+  useAsset,
+  useAssetStore,
+} from "@/registry/default/hooks/use-asset"
+import {
+  getMediaSessionPlaybackState,
+  getMediaSessionPositionState,
+  useMediaSessionActionHandlers,
+  useMediaSessionSync,
+} from "@/registry/default/hooks/use-media-session"
+import { usePlaybackStore } from "@/registry/default/hooks/use-playback"
+import { useTimelineStore } from "@/registry/default/hooks/use-timeline"
+
+export function AudioMediaSessionController() {
+  const mediaApi = useMediaApi()
+  const { currentItem, hasNext, hasPrevious } = useAsset<AudioPlayerAsset>()
+  const currentTime = useTimelineStore((state) => state.currentTime)
+  const duration = useTimelineStore((state) => state.duration)
+  const sourceType = useAssetStore((state) => state.sourceType)
+  const status = usePlaybackStore((state) => state.status)
+  const asset = currentItem?.properties ?? null
+  const active = asset !== null
+  const playlistSource = isPlaylistSource(sourceType)
+
+  const metadata = React.useMemo(
+    () => (asset ? getAudioMediaSessionMetadata(asset) : null),
+    [asset]
+  )
+  const position = React.useMemo(
+    () =>
+      getMediaSessionPositionState({
+        active,
+        currentTime,
+        duration,
+      }),
+    [active, currentTime, duration]
+  )
+  const actions = useMediaSessionActionHandlers({
+    canGoNext: playlistSource && hasNext,
+    canGoPrevious: playlistSource && hasPrevious,
+    getCurrentTime: () => {
+      const state = mediaApi.getState()
+
+      return getCurrentTimelineTime({
+        currentTime: state.timeline.currentTime,
+        isLive: state.timeline.isLive,
+        mediaElement: state.media.mediaElement,
+      })
+    },
+    getSeekRange: () => {
+      const state = mediaApi.getState()
+
+      return state.timeline.isLive ? state.player.instance?.seekRange() : null
+    },
+    onNextTrack: () => {
+      const state = mediaApi.getState()
+      if (canMoveToNextTrack(state.asset.sourceType, state.playlist)) {
+        state.playlist.next()
+      }
+    },
+    onPause: () => {
+      mediaApi.getState().playback.pause()
+    },
+    onPlay: () => mediaApi.getState().playback.play(),
+    onPreviousTrack: () => {
+      const state = mediaApi.getState()
+      if (canMoveToPreviousTrack(state.asset.sourceType, state.playlist)) {
+        state.playlist.previous()
+      }
+    },
+    onSeek: (time) => {
+      mediaApi.getState().timeline.seek(time)
+    },
+  })
+
+  useMediaSessionSync({
+    actions,
+    active,
+    metadata,
+    playbackState: getMediaSessionPlaybackState({ active, status }),
+    position,
+  })
+
+  return null
+}
+
+function canMoveToNextTrack(
+  sourceType: AssetSourceType | null,
+  playlist: PlaylistStore["playlist"]
+): boolean {
+  return isPlaylistSource(sourceType) && hasNextPlaylistItem(playlist)
+}
+
+function canMoveToPreviousTrack(
+  sourceType: AssetSourceType | null,
+  playlist: PlaylistStore["playlist"]
+): boolean {
+  return isPlaylistSource(sourceType) && hasPreviousPlaylistItem(playlist)
+}
+
+function firstNonEmpty(
+  ...values: (null | number | string | undefined)[]
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value)
+    }
+
+    if (typeof value !== "string") continue
+
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+
+  return undefined
+}
+
+function getAudioMediaSessionMetadata(
+  asset: AudioPlayerAsset
+): MediaMetadataInit {
+  const metadata = getAudioAssetMetadata(asset)
+  const poster = firstNonEmpty(metadata.poster, asset.poster)
+
+  return {
+    album: firstNonEmpty(asset.albumName),
+    artist: firstNonEmpty(asset.artistName, metadata.subtitle),
+    artwork: poster ? [{ sizes: "512x512", src: poster }] : [],
+    title: metadata.title,
+  }
+}
+
+function getCurrentTimelineTime({
+  currentTime,
+  isLive,
+  mediaElement,
+}: {
+  currentTime: number
+  isLive: boolean
+  mediaElement: HTMLMediaElement | null
+}): number {
+  return isLive && mediaElement ? mediaElement.currentTime : currentTime
+}
+
+function hasNextPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getNextIndex() !== -1
+}
+
+function hasPreviousPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getPreviousIndex() !== -1
+}
+
+function isPlaylistSource(sourceType: AssetSourceType | null): boolean {
+  return sourceType === AssetSourceType.Playlist
+}

--- a/apps/www/registry/default/blocks/audio-player/lib/media-kit.ts
+++ b/apps/www/registry/default/blocks/audio-player/lib/media-kit.ts
@@ -24,3 +24,4 @@ export const media = createMediaKit({
 })
 
 export const MediaProvider = media.MediaProvider
+export const useMediaApi = media.useMediaApi

--- a/apps/www/registry/default/blocks/audio-player/player.tsx
+++ b/apps/www/registry/default/blocks/audio-player/player.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 import { AudioSourceProvider } from "@/registry/default/blocks/audio-player/components/audio-source"
 import { PlayerControls } from "@/registry/default/blocks/audio-player/components/controls"
 import { TimelineControl } from "@/registry/default/blocks/audio-player/components/fixed-timeline-control"
+import { AudioMediaSessionController } from "@/registry/default/blocks/audio-player/components/media-session-controller"
 import { MediaProvider } from "@/registry/default/blocks/audio-player/lib/media-kit"
 import { Media } from "@/registry/default/ui/media"
 import { RootContainer } from "@/registry/default/ui/root-container"
@@ -86,6 +87,7 @@ export const AudioPlayer = React.forwardRef<HTMLDivElement, AudioPlayerProps>(
           source={source}
           sourceKey={sourceKey}
         >
+          <AudioMediaSessionController />
           <RootContainer
             aria-label="Audio player"
             aspectRatio={false}

--- a/apps/www/registry/default/blocks/video-player/components/media-session-controller.tsx
+++ b/apps/www/registry/default/blocks/video-player/components/media-session-controller.tsx
@@ -3,17 +3,18 @@
 import * as React from "react"
 
 import type { VideoPlayerAsset } from "@/registry/default/blocks/video-player/player"
-import type { PlaylistStore } from "@/registry/default/hooks/use-playlist"
 
 import { useMediaApi } from "@/registry/default/blocks/video-player/lib/media-kit"
+import { useAsset, useAssetStore } from "@/registry/default/hooks/use-asset"
 import {
-  AssetSourceType,
-  useAsset,
-  useAssetStore,
-} from "@/registry/default/hooks/use-asset"
-import {
+  canMoveToNextMediaSessionTrack,
+  canMoveToPreviousMediaSessionTrack,
+  canStartMediaSessionPlayback,
+  getMediaSessionCurrentTime,
+  getMediaSessionMetadataValue,
   getMediaSessionPlaybackState,
   getMediaSessionPositionState,
+  isMediaSessionPlaylistSource,
   useMediaSessionActionHandlers,
   useMediaSessionSync,
 } from "@/registry/default/hooks/use-media-session"
@@ -24,7 +25,7 @@ import { useTimelineStore } from "@/registry/default/hooks/use-timeline"
 
 export function VideoMediaSessionController() {
   const mediaApi = useMediaApi()
-  const { currentItem, hasNext, hasPrevious } = useAsset<VideoPlayerAsset>()
+  const { currentItem } = useAsset<VideoPlayerAsset>()
   const currentTime = useTimelineStore((state) => state.currentTime)
   const duration = useTimelineStore((state) => state.duration)
   const pictureInPictureSupported = usePictureInPictureStore(
@@ -35,7 +36,7 @@ export function VideoMediaSessionController() {
   const status = usePlaybackStore((state) => state.status)
   const asset = currentItem?.properties ?? null
   const active = asset !== null
-  const playlistSource = isPlaylistSource(sourceType)
+  const playlistSource = isMediaSessionPlaylistSource(sourceType)
 
   const metadata = React.useMemo(
     () => (asset ? getVideoMediaSessionMetadata(asset) : null),
@@ -54,12 +55,12 @@ export function VideoMediaSessionController() {
 
   const actions = useMediaSessionActionHandlers({
     canEnterPictureInPicture: active && pictureInPictureSupported,
-    canGoNext: playlistSource && hasNext,
-    canGoPrevious: playlistSource && hasPrevious,
+    canGoNext: playlistSource,
+    canGoPrevious: playlistSource,
     getCurrentTime: () => {
       const state = mediaApi.getState()
 
-      return getCurrentTimelineTime({
+      return getMediaSessionCurrentTime({
         currentTime: state.timeline.currentTime,
         isLive: state.timeline.isLive,
         mediaElement: state.media.mediaElement,
@@ -75,17 +76,29 @@ export function VideoMediaSessionController() {
     },
     onNextTrack: () => {
       const state = mediaApi.getState()
-      if (canMoveToNextTrack(state.asset.sourceType, state.playlist)) {
+      if (
+        canMoveToNextMediaSessionTrack(state.asset.sourceType, state.playlist)
+      ) {
         state.playlist.next()
       }
     },
     onPause: () => {
       mediaApi.getState().playback.pause()
     },
-    onPlay: () => mediaApi.getState().playback.play(),
+    onPlay: () => {
+      const state = mediaApi.getState()
+      if (!canStartMediaSessionPlayback(state.playback.status)) return
+
+      return state.playback.play()
+    },
     onPreviousTrack: () => {
       const state = mediaApi.getState()
-      if (canMoveToPreviousTrack(state.asset.sourceType, state.playlist)) {
+      if (
+        canMoveToPreviousMediaSessionTrack(
+          state.asset.sourceType,
+          state.playlist
+        )
+      ) {
         state.playlist.previous()
       }
     },
@@ -105,55 +118,12 @@ export function VideoMediaSessionController() {
   return null
 }
 
-function canMoveToNextTrack(
-  sourceType: AssetSourceType | null,
-  playlist: PlaylistStore["playlist"]
-): boolean {
-  return isPlaylistSource(sourceType) && hasNextPlaylistItem(playlist)
-}
-
-function canMoveToPreviousTrack(
-  sourceType: AssetSourceType | null,
-  playlist: PlaylistStore["playlist"]
-): boolean {
-  return isPlaylistSource(sourceType) && hasPreviousPlaylistItem(playlist)
-}
-
-function firstNonEmpty(
-  ...values: (null | number | string | undefined)[]
-): string | undefined {
-  for (const value of values) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      return String(value)
-    }
-
-    if (typeof value !== "string") continue
-
-    const trimmed = value.trim()
-    if (trimmed) return trimmed
-  }
-
-  return undefined
-}
-
-function getCurrentTimelineTime({
-  currentTime,
-  isLive,
-  mediaElement,
-}: {
-  currentTime: number
-  isLive: boolean
-  mediaElement: HTMLMediaElement | null
-}): number {
-  return isLive && mediaElement ? mediaElement.currentTime : currentTime
-}
-
 function getVideoMediaSessionMetadata(
   asset: VideoPlayerAsset
 ): MediaMetadataInit | null {
-  const title = firstNonEmpty(asset.title)
-  const artist = firstNonEmpty(asset.description, asset.year)
-  const poster = firstNonEmpty(asset.poster)
+  const title = getMediaSessionMetadataValue(asset.title)
+  const artist = getMediaSessionMetadataValue(asset.description, asset.year)
+  const poster = getMediaSessionMetadataValue(asset.poster)
 
   if (!title && !artist && !poster) return null
 
@@ -162,20 +132,4 @@ function getVideoMediaSessionMetadata(
     artwork: poster ? [{ sizes: "512x512", src: poster }] : [],
     title,
   }
-}
-
-function hasNextPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
-  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
-
-  return playlist.getNextIndex() !== -1
-}
-
-function hasPreviousPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
-  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
-
-  return playlist.getPreviousIndex() !== -1
-}
-
-function isPlaylistSource(sourceType: AssetSourceType | null): boolean {
-  return sourceType === AssetSourceType.Playlist
 }

--- a/apps/www/registry/default/blocks/video-player/components/media-session-controller.tsx
+++ b/apps/www/registry/default/blocks/video-player/components/media-session-controller.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+import * as React from "react"
+
+import type { VideoPlayerAsset } from "@/registry/default/blocks/video-player/player"
+import type { PlaylistStore } from "@/registry/default/hooks/use-playlist"
+
+import { useMediaApi } from "@/registry/default/blocks/video-player/lib/media-kit"
+import {
+  AssetSourceType,
+  useAsset,
+  useAssetStore,
+} from "@/registry/default/hooks/use-asset"
+import {
+  getMediaSessionPlaybackState,
+  getMediaSessionPositionState,
+  useMediaSessionActionHandlers,
+  useMediaSessionSync,
+} from "@/registry/default/hooks/use-media-session"
+import { usePictureInPictureStore } from "@/registry/default/hooks/use-picture-in-picture"
+import { usePlaybackStore } from "@/registry/default/hooks/use-playback"
+import { usePlaybackRateStore } from "@/registry/default/hooks/use-playback-rate"
+import { useTimelineStore } from "@/registry/default/hooks/use-timeline"
+
+export function VideoMediaSessionController() {
+  const mediaApi = useMediaApi()
+  const { currentItem, hasNext, hasPrevious } = useAsset<VideoPlayerAsset>()
+  const currentTime = useTimelineStore((state) => state.currentTime)
+  const duration = useTimelineStore((state) => state.duration)
+  const pictureInPictureSupported = usePictureInPictureStore(
+    (state) => state.supported
+  )
+  const playbackRate = usePlaybackRateStore((state) => state.value)
+  const sourceType = useAssetStore((state) => state.sourceType)
+  const status = usePlaybackStore((state) => state.status)
+  const asset = currentItem?.properties ?? null
+  const active = asset !== null
+  const playlistSource = isPlaylistSource(sourceType)
+
+  const metadata = React.useMemo(
+    () => (asset ? getVideoMediaSessionMetadata(asset) : null),
+    [asset]
+  )
+  const position = React.useMemo(
+    () =>
+      getMediaSessionPositionState({
+        active,
+        currentTime,
+        duration,
+        playbackRate,
+      }),
+    [active, currentTime, duration, playbackRate]
+  )
+
+  const actions = useMediaSessionActionHandlers({
+    canEnterPictureInPicture: active && pictureInPictureSupported,
+    canGoNext: playlistSource && hasNext,
+    canGoPrevious: playlistSource && hasPrevious,
+    getCurrentTime: () => {
+      const state = mediaApi.getState()
+
+      return getCurrentTimelineTime({
+        currentTime: state.timeline.currentTime,
+        isLive: state.timeline.isLive,
+        mediaElement: state.media.mediaElement,
+      })
+    },
+    getSeekRange: () => {
+      const state = mediaApi.getState()
+
+      return state.timeline.isLive ? state.player.instance?.seekRange() : null
+    },
+    onEnterPictureInPicture: () => {
+      void mediaApi.getState().pictureInPicture.enter()
+    },
+    onNextTrack: () => {
+      const state = mediaApi.getState()
+      if (canMoveToNextTrack(state.asset.sourceType, state.playlist)) {
+        state.playlist.next()
+      }
+    },
+    onPause: () => {
+      mediaApi.getState().playback.pause()
+    },
+    onPlay: () => mediaApi.getState().playback.play(),
+    onPreviousTrack: () => {
+      const state = mediaApi.getState()
+      if (canMoveToPreviousTrack(state.asset.sourceType, state.playlist)) {
+        state.playlist.previous()
+      }
+    },
+    onSeek: (time) => {
+      mediaApi.getState().timeline.seek(time)
+    },
+  })
+
+  useMediaSessionSync({
+    actions,
+    active,
+    metadata,
+    playbackState: getMediaSessionPlaybackState({ active, status }),
+    position,
+  })
+
+  return null
+}
+
+function canMoveToNextTrack(
+  sourceType: AssetSourceType | null,
+  playlist: PlaylistStore["playlist"]
+): boolean {
+  return isPlaylistSource(sourceType) && hasNextPlaylistItem(playlist)
+}
+
+function canMoveToPreviousTrack(
+  sourceType: AssetSourceType | null,
+  playlist: PlaylistStore["playlist"]
+): boolean {
+  return isPlaylistSource(sourceType) && hasPreviousPlaylistItem(playlist)
+}
+
+function firstNonEmpty(
+  ...values: (null | number | string | undefined)[]
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value)
+    }
+
+    if (typeof value !== "string") continue
+
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+
+  return undefined
+}
+
+function getCurrentTimelineTime({
+  currentTime,
+  isLive,
+  mediaElement,
+}: {
+  currentTime: number
+  isLive: boolean
+  mediaElement: HTMLMediaElement | null
+}): number {
+  return isLive && mediaElement ? mediaElement.currentTime : currentTime
+}
+
+function getVideoMediaSessionMetadata(
+  asset: VideoPlayerAsset
+): MediaMetadataInit | null {
+  const title = firstNonEmpty(asset.title)
+  const artist = firstNonEmpty(asset.description, asset.year)
+  const poster = firstNonEmpty(asset.poster)
+
+  if (!title && !artist && !poster) return null
+
+  return {
+    artist,
+    artwork: poster ? [{ sizes: "512x512", src: poster }] : [],
+    title,
+  }
+}
+
+function hasNextPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getNextIndex() !== -1
+}
+
+function hasPreviousPlaylistItem(playlist: PlaylistStore["playlist"]): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getPreviousIndex() !== -1
+}
+
+function isPlaylistSource(sourceType: AssetSourceType | null): boolean {
+  return sourceType === AssetSourceType.Playlist
+}

--- a/apps/www/registry/default/blocks/video-player/lib/media-kit.ts
+++ b/apps/www/registry/default/blocks/video-player/lib/media-kit.ts
@@ -28,4 +28,5 @@ export const media = createMediaKit({
 })
 
 export const MediaProvider = media.MediaProvider
+export const useMediaApi = media.useMediaApi
 export const useMediaEvents = media.useMediaEvents

--- a/apps/www/registry/default/blocks/video-player/player.tsx
+++ b/apps/www/registry/default/blocks/video-player/player.tsx
@@ -6,6 +6,7 @@ import type { PlaybackSourceControllerProps } from "@/registry/default/hooks/use
 
 import { cn } from "@/lib/utils"
 import { BottomControls } from "@/registry/default/blocks/video-player/components/bottom-controls"
+import { VideoMediaSessionController } from "@/registry/default/blocks/video-player/components/media-session-controller"
 import { PlayerErrorScreen } from "@/registry/default/blocks/video-player/components/player-error-screen"
 import {
   PlayerRootContainer,
@@ -84,6 +85,7 @@ export const VideoPlayer = React.forwardRef<HTMLDivElement, VideoPlayerProps>(
             source={source}
             sourceKey={sourceKey}
           />
+          <VideoMediaSessionController />
           <PlayerErrorScreen
             initialIndex={initialIndex}
             loading={loading}
@@ -159,6 +161,7 @@ export const VideoPlayer = React.forwardRef<HTMLDivElement, VideoPlayerProps>(
 
 VideoPlayer.displayName = "VideoPlayer"
 
+// TODO: Fix this to FallbackPoster component with multisupport
 function CurrentAssetMedia({
   className,
   poster,
@@ -171,7 +174,7 @@ function CurrentAssetMedia({
     <Media
       {...(mediaProps as React.ComponentPropsWithoutRef<typeof Media>)}
       as="video"
-      className={cn("size-full object-contain", className)}
+      className={cn("size-full bg-black object-contain", className)}
       poster={poster ?? currentPoster}
     />
   )

--- a/apps/www/registry/default/hooks/use-media-session.ts
+++ b/apps/www/registry/default/hooks/use-media-session.ts
@@ -30,6 +30,15 @@ export interface MediaSessionPictureInPictureActionDetails extends MediaSessionA
   enterPictureInPictureReason?: "contentoccluded" | "other" | "useraction"
 }
 
+export interface MediaSessionPlaylistNavigation {
+  getNextIndex: () => number
+  getPreviousIndex: () => number
+  queue: readonly unknown[]
+  repeatMode: "all" | "off" | "one"
+}
+
+export type MediaSessionSourceType = "asset" | "playlist" | null
+
 export interface UseMediaSessionActionHandlersOptions {
   canEnterPictureInPicture?: boolean
   canGoNext?: boolean
@@ -74,6 +83,59 @@ type MaybePromise<T> = Promise<T> | T
 
 const DEFAULT_MEDIA_SESSION_SEEK_OFFSET_SECONDS = 10
 
+export function canMoveToNextMediaSessionTrack(
+  sourceType: MediaSessionSourceType,
+  playlist: MediaSessionPlaylistNavigation
+): boolean {
+  return (
+    isMediaSessionPlaylistSource(sourceType) &&
+    hasNextMediaSessionPlaylistItem(playlist)
+  )
+}
+
+export function canMoveToPreviousMediaSessionTrack(
+  sourceType: MediaSessionSourceType,
+  playlist: MediaSessionPlaylistNavigation
+): boolean {
+  return (
+    isMediaSessionPlaylistSource(sourceType) &&
+    hasPreviousMediaSessionPlaylistItem(playlist)
+  )
+}
+
+export function canStartMediaSessionPlayback(status: string): boolean {
+  return !["error", "init"].includes(status)
+}
+
+export function getMediaSessionCurrentTime({
+  currentTime,
+  isLive,
+  mediaElement,
+}: {
+  currentTime: number
+  isLive: boolean
+  mediaElement: HTMLMediaElement | null
+}): number {
+  return isLive && mediaElement ? mediaElement.currentTime : currentTime
+}
+
+export function getMediaSessionMetadataValue(
+  ...values: (null | number | string | undefined)[]
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value)
+    }
+
+    if (typeof value !== "string") continue
+
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+
+  return undefined
+}
+
 export function getMediaSessionPlaybackState({
   active,
   status,
@@ -107,6 +169,12 @@ export function getMediaSessionPositionState({
     playbackRate,
     position: getSafePosition(currentTime, duration),
   }
+}
+
+export function isMediaSessionPlaylistSource(
+  sourceType: MediaSessionSourceType
+): boolean {
+  return sourceType === "playlist"
 }
 
 export function useMediaSession(): UseMediaSessionReturn {
@@ -309,13 +377,26 @@ export function useMediaSessionSync({
   const mediaSession = useMediaSession()
 
   React.useEffect(() => {
+    const cleanupHandlers = getActionEntries(actions).map(([action, handler]) =>
+      mediaSession.setActionHandler(action, active ? (handler ?? null) : null)
+    )
+
+    return () => {
+      cleanupHandlers.forEach((cleanup) => cleanup())
+    }
+  }, [actions, active, mediaSession])
+
+  // Publish metadata after the current action set so platform UIs choose the
+  // correct track-navigation or seek-control layout for this source. Republish
+  // when actions change even if the metadata values stay the same.
+  React.useEffect(() => {
     if (!active || !metadata) {
       mediaSession.clearMetadata()
       return
     }
 
     mediaSession.setMetadata(metadata)
-  }, [active, mediaSession, metadata])
+  }, [actions, active, mediaSession, metadata])
 
   React.useEffect(() => {
     mediaSession.setPlaybackState(active ? (playbackState ?? "none") : "none")
@@ -329,16 +410,6 @@ export function useMediaSessionSync({
 
     mediaSession.setPositionState(position)
   }, [active, mediaSession, position])
-
-  React.useEffect(() => {
-    const cleanupHandlers = getActionEntries(actions).map(([action, handler]) =>
-      mediaSession.setActionHandler(action, active ? (handler ?? null) : null)
-    )
-
-    return () => {
-      cleanupHandlers.forEach((cleanup) => cleanup())
-    }
-  }, [actions, active, mediaSession])
 
   React.useEffect(() => {
     return () => {
@@ -376,6 +447,22 @@ function getSeekOffset({
   seekOffset,
 }: UseMediaSessionActionHandlersOptions): number {
   return seekOffset ?? DEFAULT_MEDIA_SESSION_SEEK_OFFSET_SECONDS
+}
+
+function hasNextMediaSessionPlaylistItem(
+  playlist: MediaSessionPlaylistNavigation
+): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getNextIndex() !== -1
+}
+
+function hasPreviousMediaSessionPlaylistItem(
+  playlist: MediaSessionPlaylistNavigation
+): boolean {
+  if (playlist.repeatMode === "all" && playlist.queue.length > 0) return true
+
+  return playlist.getPreviousIndex() !== -1
 }
 
 function isMediaSessionSupported(): boolean {

--- a/apps/www/registry/default/hooks/use-media-session.ts
+++ b/apps/www/registry/default/hooks/use-media-session.ts
@@ -1,0 +1,452 @@
+"use client"
+
+import * as React from "react"
+
+export type MediaSessionActionHandlers = Partial<
+  Record<MediaSessionActionName, MediaSessionActionHandler | null>
+>
+
+export type MediaSessionActionName =
+  | "enterpictureinpicture"
+  | "hangup"
+  | "nextslide"
+  | "previousslide"
+  | "togglecamera"
+  | "togglemicrophone"
+  | "togglescreenshare"
+  | MediaSessionAction
+
+export interface MediaSessionChapterInformationInit {
+  artwork?: MediaImage[]
+  startTime?: number
+  title?: string
+}
+
+export type MediaSessionMetadata = MediaMetadataInit & {
+  chapterInfo?: MediaSessionChapterInformationInit[]
+}
+
+export interface MediaSessionPictureInPictureActionDetails extends MediaSessionActionDetails {
+  enterPictureInPictureReason?: "contentoccluded" | "other" | "useraction"
+}
+
+export interface UseMediaSessionActionHandlersOptions {
+  canEnterPictureInPicture?: boolean
+  canGoNext?: boolean
+  canGoPrevious?: boolean
+  getCurrentTime: () => number
+  getSeekRange?: () => null | undefined | { start: number }
+  onEnterPictureInPicture?: (
+    details: MediaSessionPictureInPictureActionDetails
+  ) => void
+  onNextTrack?: () => void
+  onPause: () => void
+  onPlay: () => MaybePromise<void>
+  onPreviousTrack?: () => void
+  onSeek: (time: number, details: MediaSessionActionDetails) => void
+  onSkipAd?: () => void
+  onStop?: () => void
+  seekOffset?: number
+}
+
+export interface UseMediaSessionReturn {
+  clearMetadata: () => void
+  clearPositionState: () => void
+  setActionHandler: (
+    action: MediaSessionActionName,
+    handler: MediaSessionActionHandler | null
+  ) => () => void
+  setMetadata: (metadata: MediaSessionMetadata) => void
+  setPlaybackState: (state: MediaSessionPlaybackState) => void
+  setPositionState: (state: MediaPositionState) => void
+  supported: boolean
+}
+
+export interface UseMediaSessionSyncOptions {
+  actions?: MediaSessionActionHandlers
+  active?: boolean
+  metadata?: MediaSessionMetadata | null
+  playbackState?: MediaSessionPlaybackState
+  position?: MediaPositionState | null
+}
+
+type MaybePromise<T> = Promise<T> | T
+
+const DEFAULT_MEDIA_SESSION_SEEK_OFFSET_SECONDS = 10
+
+export function getMediaSessionPlaybackState({
+  active,
+  status,
+}: {
+  active: boolean
+  status: string
+}): MediaSessionPlaybackState {
+  if (!active) return "none"
+
+  return status === "playing" ? "playing" : "paused"
+}
+
+export function getMediaSessionPositionState({
+  active,
+  currentTime,
+  duration,
+  playbackRate = 1,
+}: {
+  active: boolean
+  currentTime: number
+  duration: number
+  playbackRate?: number
+}): MediaPositionState | null {
+  if (!active) return null
+  if (!isValidDuration(duration)) return null
+  if (!Number.isFinite(currentTime) || currentTime < 0) return null
+  if (!isValidPlaybackRate(playbackRate)) return null
+
+  return {
+    duration,
+    playbackRate,
+    position: getSafePosition(currentTime, duration),
+  }
+}
+
+export function useMediaSession(): UseMediaSessionReturn {
+  const supported = isMediaSessionSupported()
+
+  const clearMetadata = React.useCallback(() => {
+    const session = getMediaSession()
+    if (!session) return
+
+    session.metadata = null
+  }, [])
+
+  const clearPositionState = React.useCallback(() => {
+    const session = getMediaSession()
+    if (!session) return
+
+    try {
+      session.setPositionState()
+    } catch (error) {
+      console.warn("[useMediaSession] Failed to clear position state:", error)
+    }
+  }, [])
+
+  const setActionHandler = React.useCallback(
+    (
+      action: MediaSessionActionName,
+      handler: MediaSessionActionHandler | null
+    ) => {
+      const session = getMediaSession()
+      if (!session) return noop
+
+      setSafeActionHandler(session, action, handler)
+
+      return () => {
+        setSafeActionHandler(session, action, null)
+      }
+    },
+    []
+  )
+
+  const setMetadata = React.useCallback((metadata: MediaSessionMetadata) => {
+    const session = getMediaSession()
+    if (
+      !session ||
+      typeof window === "undefined" ||
+      typeof window.MediaMetadata !== "function"
+    ) {
+      return
+    }
+
+    try {
+      session.metadata = new window.MediaMetadata(metadata)
+    } catch (error) {
+      console.warn("[useMediaSession] Failed to set metadata:", error)
+    }
+  }, [])
+
+  const setPlaybackState = React.useCallback(
+    (state: MediaSessionPlaybackState) => {
+      const session = getMediaSession()
+      if (!session) return
+
+      try {
+        session.playbackState = state
+      } catch (error) {
+        console.warn("[useMediaSession] Failed to set playback state:", error)
+      }
+    },
+    []
+  )
+
+  const setPositionState = React.useCallback((state: MediaPositionState) => {
+    const session = getMediaSession()
+    if (!session) return
+
+    const safeState = normalizePositionState(state)
+    if (!safeState) return
+
+    try {
+      session.setPositionState(safeState)
+    } catch (error) {
+      console.warn("[useMediaSession] Failed to set position state:", error)
+    }
+  }, [])
+
+  return React.useMemo(
+    () => ({
+      clearMetadata,
+      clearPositionState,
+      setActionHandler,
+      setMetadata,
+      setPlaybackState,
+      setPositionState,
+      supported,
+    }),
+    [
+      clearMetadata,
+      clearPositionState,
+      setActionHandler,
+      setMetadata,
+      setPlaybackState,
+      setPositionState,
+      supported,
+    ]
+  )
+}
+
+export function useMediaSessionActionHandlers(
+  options: UseMediaSessionActionHandlersOptions
+): MediaSessionActionHandlers {
+  const optionsRef = React.useRef(options)
+  optionsRef.current = options
+
+  const canEnterPictureInPicture = Boolean(
+    options.canEnterPictureInPicture && options.onEnterPictureInPicture
+  )
+  const canGoNext = Boolean(options.canGoNext && options.onNextTrack)
+  const canGoPrevious = Boolean(
+    options.canGoPrevious && options.onPreviousTrack
+  )
+  const canSkipAd = Boolean(options.onSkipAd)
+  const canStop = Boolean(options.onStop)
+
+  return React.useMemo(
+    () => ({
+      enterpictureinpicture: canEnterPictureInPicture
+        ? (details) => {
+            optionsRef.current.onEnterPictureInPicture?.(
+              details as MediaSessionPictureInPictureActionDetails
+            )
+          }
+        : null,
+      nexttrack: canGoNext
+        ? () => {
+            optionsRef.current.onNextTrack?.()
+          }
+        : null,
+      pause: () => {
+        optionsRef.current.onPause()
+      },
+      play: () => {
+        void optionsRef.current.onPlay()
+      },
+      previoustrack: canGoPrevious
+        ? () => {
+            optionsRef.current.onPreviousTrack?.()
+          }
+        : null,
+      seekbackward: (details) => {
+        const currentOptions = optionsRef.current
+        seekByOffset(
+          currentOptions.getCurrentTime(),
+          -(details.seekOffset ?? getSeekOffset(currentOptions)),
+          currentOptions.onSeek,
+          details
+        )
+      },
+      seekforward: (details) => {
+        const currentOptions = optionsRef.current
+        seekByOffset(
+          currentOptions.getCurrentTime(),
+          details.seekOffset ?? getSeekOffset(currentOptions),
+          currentOptions.onSeek,
+          details
+        )
+      },
+      seekto: (details) => {
+        if (typeof details.seekTime !== "number") return
+
+        const currentOptions = optionsRef.current
+        const seekRange = currentOptions.getSeekRange?.()
+        const seekTime = seekRange
+          ? seekRange.start + details.seekTime
+          : details.seekTime
+
+        currentOptions.onSeek(seekTime, details)
+      },
+      skipad: canSkipAd
+        ? () => {
+            optionsRef.current.onSkipAd?.()
+          }
+        : null,
+      stop: canStop
+        ? () => {
+            optionsRef.current.onStop?.()
+          }
+        : null,
+    }),
+    [canEnterPictureInPicture, canGoNext, canGoPrevious, canSkipAd, canStop]
+  )
+}
+
+export function useMediaSessionSync({
+  actions,
+  active = true,
+  metadata,
+  playbackState,
+  position,
+}: UseMediaSessionSyncOptions): UseMediaSessionReturn {
+  const mediaSession = useMediaSession()
+
+  React.useEffect(() => {
+    if (!active || !metadata) {
+      mediaSession.clearMetadata()
+      return
+    }
+
+    mediaSession.setMetadata(metadata)
+  }, [active, mediaSession, metadata])
+
+  React.useEffect(() => {
+    mediaSession.setPlaybackState(active ? (playbackState ?? "none") : "none")
+  }, [active, mediaSession, playbackState])
+
+  React.useEffect(() => {
+    if (!active || !position) {
+      mediaSession.clearPositionState()
+      return
+    }
+
+    mediaSession.setPositionState(position)
+  }, [active, mediaSession, position])
+
+  React.useEffect(() => {
+    const cleanupHandlers = getActionEntries(actions).map(([action, handler]) =>
+      mediaSession.setActionHandler(action, active ? (handler ?? null) : null)
+    )
+
+    return () => {
+      cleanupHandlers.forEach((cleanup) => cleanup())
+    }
+  }, [actions, active, mediaSession])
+
+  React.useEffect(() => {
+    return () => {
+      mediaSession.clearMetadata()
+      mediaSession.clearPositionState()
+      mediaSession.setPlaybackState("none")
+    }
+  }, [mediaSession])
+
+  return mediaSession
+}
+
+function getActionEntries(
+  actions: MediaSessionActionHandlers | undefined
+): [MediaSessionActionName, MediaSessionActionHandler | null | undefined][] {
+  return Object.entries(actions ?? {}) as [
+    MediaSessionActionName,
+    MediaSessionActionHandler | null | undefined,
+  ][]
+}
+
+function getMediaSession(): MediaSession | null {
+  if (!isMediaSessionSupported()) return null
+
+  const mediaSession = navigator.mediaSession as MediaSession | undefined
+
+  return mediaSession ?? null
+}
+
+function getSafePosition(position: number, duration: number): number {
+  return Number.isFinite(duration) ? Math.min(position, duration) : position
+}
+
+function getSeekOffset({
+  seekOffset,
+}: UseMediaSessionActionHandlersOptions): number {
+  return seekOffset ?? DEFAULT_MEDIA_SESSION_SEEK_OFFSET_SECONDS
+}
+
+function isMediaSessionSupported(): boolean {
+  return typeof navigator !== "undefined" && "mediaSession" in navigator
+}
+
+function isValidDuration(duration: number): boolean {
+  return duration > 0 && (Number.isFinite(duration) || duration === Infinity)
+}
+
+function isValidPlaybackRate(playbackRate: number): boolean {
+  return Number.isFinite(playbackRate) && playbackRate !== 0
+}
+
+function noop() {}
+
+function normalizePositionState(
+  state: MediaPositionState
+): MediaPositionState | null {
+  const nextState: MediaPositionState = {}
+  const hasPositionData =
+    typeof state.duration === "number" ||
+    typeof state.playbackRate === "number" ||
+    typeof state.position === "number"
+
+  if (!hasPositionData) return nextState
+
+  if (typeof state.duration !== "number" || !isValidDuration(state.duration)) {
+    return null
+  }
+
+  nextState.duration = state.duration
+
+  if (typeof state.playbackRate === "number") {
+    if (!isValidPlaybackRate(state.playbackRate)) return null
+
+    nextState.playbackRate = state.playbackRate
+  }
+
+  if (typeof state.position === "number") {
+    if (!Number.isFinite(state.position) || state.position < 0) return null
+
+    nextState.position = getSafePosition(state.position, nextState.duration)
+  }
+
+  return nextState
+}
+
+function seekByOffset(
+  currentTime: number,
+  offset: number,
+  seek: (time: number, details: MediaSessionActionDetails) => void,
+  details: MediaSessionActionDetails
+) {
+  if (!Number.isFinite(offset)) return
+  if (!Number.isFinite(currentTime)) return
+
+  seek(currentTime + offset, details)
+}
+
+function setSafeActionHandler(
+  session: MediaSession,
+  action: MediaSessionActionName,
+  handler: MediaSessionActionHandler | null
+) {
+  try {
+    session.setActionHandler(action as MediaSessionAction, handler)
+  } catch (error) {
+    console.warn(
+      `[useMediaSession] Failed to set "${action}" action handler:`,
+      error
+    )
+  }
+}

--- a/apps/www/registry/default/hooks/use-playback.ts
+++ b/apps/www/registry/default/hooks/use-playback.ts
@@ -344,17 +344,6 @@ function PlaybackSetup() {
       events.emit("statuschange", { prevStatus, status: "buffering" })
     }
 
-    const stalledHandler = () => {
-      const prevStatus = store.getState().playback.status
-
-      store.setState(({ playback }) => {
-        playback.status = "buffering"
-      })
-
-      events.emit("buffering", { isBuffering: true })
-      events.emit("statuschange", { prevStatus, status: "buffering" })
-    }
-
     const errorHandler = () => {
       store.getState().playback.setError(media.error)
     }
@@ -369,7 +358,6 @@ function PlaybackSetup() {
     on(media, "pause", pauseHandler)
     on(media, "ended", endedHandler)
     on(media, "waiting", waitingHandler)
-    on(media, "stalled", stalledHandler)
     on(media, "error", errorHandler)
 
     setInitialState()
@@ -385,7 +373,6 @@ function PlaybackSetup() {
       off(media, "pause", pauseHandler)
       off(media, "ended", endedHandler)
       off(media, "waiting", waitingHandler)
-      off(media, "stalled", stalledHandler)
       off(media, "error", errorHandler)
     }
   }, [events, store, mediaElement])

--- a/apps/www/registry/default/hooks/use-playlist.ts
+++ b/apps/www/registry/default/hooks/use-playlist.ts
@@ -14,7 +14,6 @@ import type {
 
 import { useMediaStore } from "@/registry/default/hooks/use-media"
 import {
-  useMediaEvents,
   useMediaFeatureApi,
   useMediaFeatureStore,
 } from "@/registry/default/ui/media-provider"
@@ -62,6 +61,7 @@ export interface PlaylistStore extends MediaEventSlice<PlaylistEvents> {
     next: () => boolean
     playNext: <T>(items: PlaylistItemInput<T>[]) => void
     prepend: <T>(items: PlaylistItemInput<T>[]) => void
+    previous: () => boolean
     queue: PlaylistItem[]
     remove: (id: string) => void
     removeAt: (index: number) => void
@@ -380,6 +380,35 @@ export function playlistFeature(): MediaFeature<PlaylistStore> {
             p.shuffleOrder = newShuffleOrder
           })
         },
+        previous: () => {
+          const playlist = get().playlist as PlaylistStore["playlist"]
+          const previousIndex = playlist.getPreviousIndex()
+          if (previousIndex === -1 || previousIndex >= playlist.queue.length) {
+            return false
+          }
+
+          const previousItem = playlist.queue[previousIndex] as PlaylistItem
+          const previousHistory =
+            playlist.history.length > 0
+              ? playlist.history.slice(0, -1)
+              : playlist.history
+
+          set(({ playlist: p }) => {
+            p.currentIndex = previousIndex
+            p.currentItem = previousItem
+            p.history = previousHistory
+          })
+
+          emitPlaylistChange(
+            events.emit,
+            previousIndex,
+            previousItem,
+            playlist.currentIndex,
+            playlist.currentItem,
+            "previous"
+          )
+          return true
+        },
         queue: [],
         remove: (id) => {
           const playlist = get().playlist as PlaylistStore["playlist"]
@@ -566,7 +595,6 @@ export function playlistFeature(): MediaFeature<PlaylistStore> {
 
 export function usePlaylist<T>(): UsePlaylistReturn<T> {
   const api = useMediaFeatureApi<PlaylistStore>(PLAYLIST_FEATURE_KEY)
-  const events = useMediaEvents<PlaylistEvents>()
   const currentIndex = usePlaylistStore((state) => state.currentIndex)
   const queue = usePlaylistStore((state) => state.queue)
   const shuffle = usePlaylistStore((state) => state.shuffle)
@@ -586,6 +614,7 @@ export function usePlaylist<T>(): UsePlaylistReturn<T> {
       next: playlist.next,
       playNext: playlist.playNext as UsePlaylistReturn<T>["playNext"],
       prepend: playlist.prepend as UsePlaylistReturn<T>["prepend"],
+      previous: playlist.previous,
       remove: playlist.remove,
       removeAt: playlist.removeAt,
       reorder: playlist.reorder,
@@ -638,34 +667,6 @@ export function usePlaylist<T>(): UsePlaylistReturn<T> {
     (repeatMode === "all" && queue.length > 0) ||
     api.getState().playlist.getPreviousIndex() !== -1
 
-  const previous = React.useCallback(() => {
-    const prevIndex = api.getState().playlist.getPreviousIndex()
-    if (prevIndex === -1 || prevIndex >= queue.length) return false
-
-    const playlist = api.getState().playlist as PlaylistStore["playlist"]
-
-    if (playlist.history.length > 0) {
-      api.setState(({ playlist: p }) => {
-        p.history = playlist.history.slice(0, -1)
-      })
-    }
-
-    const targetItem = queue[prevIndex] as PlaylistItem
-    api.setState(({ playlist: p }) => {
-      p.currentIndex = prevIndex
-      p.currentItem = targetItem
-    })
-    emitPlaylistChange(
-      events.emit,
-      prevIndex,
-      targetItem,
-      playlist.currentIndex,
-      playlist.currentItem,
-      "previous"
-    )
-    return true
-  }, [api, events, queue])
-
   return {
     append: state.append,
     clear: state.clear,
@@ -683,7 +684,7 @@ export function usePlaylist<T>(): UsePlaylistReturn<T> {
     orderedItems,
     playNext: state.playNext,
     prepend: state.prepend,
-    previous,
+    previous: state.previous,
     previousItem,
     remove: state.remove,
     removeAt: state.removeAt,

--- a/apps/www/registry/default/hooks/use-playlist.ts
+++ b/apps/www/registry/default/hooks/use-playlist.ts
@@ -388,8 +388,9 @@ export function playlistFeature(): MediaFeature<PlaylistStore> {
           }
 
           const previousItem = playlist.queue[previousIndex] as PlaylistItem
+          const lastHistoryItem = playlist.history.at(-1)
           const previousHistory =
-            playlist.history.length > 0
+            lastHistoryItem?.id === previousItem.id
               ? playlist.history.slice(0, -1)
               : playlist.history
 

--- a/apps/www/registry/default/ui/timeline-control.tsx
+++ b/apps/www/registry/default/ui/timeline-control.tsx
@@ -243,7 +243,7 @@ Buffered.displayName = "SliderBuffered"
 
 export const Thumb = React.forwardRef<HTMLDivElement, ThumbProps>(
   (props, ref) => {
-    const { className, position, showWithHover = false, ...etc } = props
+    const { className, position, showWithHover = false, style, ...etc } = props
     const hoveringTime = useTimelineStore((state) => state.hoveringTime)
     const duration = useTimelineStore((state) => state.duration)
     const currentTime = useTimelineStore((state) => state.currentTime)
@@ -266,7 +266,7 @@ export const Thumb = React.forwardRef<HTMLDivElement, ThumbProps>(
       <SliderPrimitive.Thumb
         className={cn(
           `
-            left-(--lp-timeline-thumb-position)! bg-primary
+            left-(--lp-timeline-thumb-left,var(--lp-timeline-thumb-position))! bg-primary
             data-disabled:bg-primary/85
           `,
           className
@@ -276,7 +276,8 @@ export const Thumb = React.forwardRef<HTMLDivElement, ThumbProps>(
         style={
           {
             "--lp-timeline-thumb-position": `${finalPosition}%`,
-          } as React.CSSProperties
+            ...style,
+          } as unknown as React.CSSProperties
         }
       />
     )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/WINOFFRG/limeplay/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser Media Session support to audio and video players, including metadata, playback controls, seeking, track navigation, and picture-in-picture actions.
  * Added reusable Media Session utilities and previous-track playlist navigation.
* **Bug Fixes**
  * Improved timeline thumb positioning and transitions.
  * Removed unreliable stalled-event buffering updates.
  * Improved video presentation with a black background.
* **Documentation**
  * Expanded player and hook documentation with Media Session capabilities.
* **Chores**
  * Improved site metadata, search-engine directives, and verification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->