### PR TITLE
fix: shaka opus loading on safari hls

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -57,7 +57,7 @@
     "react-use": "^17.6.1",
     "remark-code-import": "^1.2.0",
     "remark-gfm": "^4.0.1",
-    "shaka-player": "^4.16.44",
+    "shaka-player": "^5.2.7",
     "three": "^0.185.1",
     "ts-morph": "28.0.0",
     "tw-animate-css": "^1.4.0",

--- a/apps/www/registry/collection/registry-blocks.ts
+++ b/apps/www/registry/collection/registry-blocks.ts
@@ -10,7 +10,7 @@ export const blocks: Registry["items"] = [
       "@base-ui/react",
       "@radix-ui/react-toggle",
       "zustand",
-      "shaka-player@^4",
+      "shaka-player@^5.2.7",
       "lodash.clamp",
     ],
     description: "Modern seamless flat video player",
@@ -145,7 +145,7 @@ export const blocks: Registry["items"] = [
       "@radix-ui/react-slot",
       "motion",
       "zustand",
-      "shaka-player@^4",
+      "shaka-player@^5.2.7",
     ],
     description: "Compact audio player with playlist support",
     files: [

--- a/apps/www/registry/collection/registry-hooks.ts
+++ b/apps/www/registry/collection/registry-hooks.ts
@@ -63,7 +63,7 @@ export const hooks: Registry["items"] = [
     type: "registry:hook",
   },
   {
-    dependencies: ["lodash.clamp", "shaka-player@^4", "zustand"],
+    dependencies: ["lodash.clamp", "shaka-player@^5.2.7", "zustand"],
     devDependencies: ["@types/lodash.clamp"],
     files: [
       {
@@ -84,7 +84,7 @@ export const hooks: Registry["items"] = [
     type: "registry:hook",
   },
   {
-    dependencies: ["shaka-player@^4", "zustand"],
+    dependencies: ["shaka-player@^5.2.7", "zustand"],
     files: [
       {
         path: "hooks/use-player.ts",
@@ -102,7 +102,7 @@ export const hooks: Registry["items"] = [
     type: "registry:hook",
   },
   {
-    dependencies: ["shaka-player@^4", "zustand"],
+    dependencies: ["shaka-player@^5.2.7", "zustand"],
     files: [
       {
         path: "hooks/use-asset.ts",
@@ -144,7 +144,7 @@ export const hooks: Registry["items"] = [
     type: "registry:hook",
   },
   {
-    dependencies: ["shaka-player@^4", "zustand"],
+    dependencies: ["shaka-player@^5.2.7", "zustand"],
     files: [
       {
         path: "hooks/use-captions.ts",

--- a/apps/www/registry/collection/registry-ui.ts
+++ b/apps/www/registry/collection/registry-ui.ts
@@ -4,7 +4,7 @@ const TARGET_BASE_PATH = "components/limeplay"
 
 export const ui: Registry["items"] = [
   {
-    dependencies: ["shaka-player@^4"],
+    dependencies: ["shaka-player@^5.2.7"],
     files: [
       {
         path: "ui/error-screen.tsx",

--- a/apps/www/registry/default/examples/captions-state-control-demo.tsx
+++ b/apps/www/registry/default/examples/captions-state-control-demo.tsx
@@ -39,7 +39,6 @@ export function CaptionsStateControlDemo() {
       )
       .then(() => {
         player.selectTextTrack(player.getTextTracks()[0])
-        player.setTextTrackVisibility(true)
       })
       .catch((error: unknown) => {
         console.error("Error adding text track:", error)

--- a/apps/www/registry/default/hooks/use-captions.ts
+++ b/apps/www/registry/default/hooks/use-captions.ts
@@ -12,6 +12,7 @@ import type {
 import { useMediaStore } from "@/registry/default/hooks/use-media"
 import { usePlaybackStore } from "@/registry/default/hooks/use-playback"
 import {
+  PLAYER_FEATURE_KEY,
   type PlayerStore,
   usePlayerStore,
 } from "@/registry/default/hooks/use-player"
@@ -91,12 +92,14 @@ export function useCaptionsStore<TSelected>(
 
 function CaptionsSetup() {
   const store = useMediaFeatureApi<CaptionsStore>(CAPTIONS_FEATURE_KEY)
+  const playerStore = useMediaFeatureApi<PlayerStore>(PLAYER_FEATURE_KEY)
   const player = usePlayerStore((state) => state.instance)
   const containerElement = useCaptionsStore((state) => state.containerElement)
   const mediaElement = useMediaStore((state) => state.mediaElement)
   const canPlay = usePlaybackStore((state) => state.canPlay)
 
   const syncTextTrackState = () => {
+    const player = playerStore.getState().player.instance
     if (!player) {
       return
     }

--- a/apps/www/registry/default/hooks/use-captions.ts
+++ b/apps/www/registry/default/hooks/use-captions.ts
@@ -56,22 +56,16 @@ export function captionsFeature(): MediaFeature<
 
           const captions = get().captions
 
-          if (!captions.activeTrack) {
-            const defaultTrack = findDefaultTrack(captions.tracks)
-            if (defaultTrack) {
-              player.selectTextTrack(defaultTrack)
-
-              const activeTrack = player
-                .getTextTracks()
-                .find((track: shaka.extern.TextTrack) => track.active)
-
-              set(({ captions }) => {
-                captions.activeTrack = activeTrack ?? null
-              })
-            }
+          if (captions.visible) {
+            player.selectTextTrack(null)
+            return
           }
 
-          player.setTextTrackVisibility(!captions.visible)
+          const track =
+            captions.activeTrack ?? findDefaultTrack(captions.tracks)
+          if (track) {
+            player.selectTextTrack(track)
+          }
         },
         tracks: undefined,
         visible: false,
@@ -102,37 +96,20 @@ function CaptionsSetup() {
   const mediaElement = useMediaStore((state) => state.mediaElement)
   const canPlay = usePlaybackStore((state) => state.canPlay)
 
-  const onTextTrackChanged = () => {
+  const syncTextTrackState = () => {
     if (!player) {
       return
     }
 
-    const activeTrack = player
-      .getTextTracks()
-      .find((track: shaka.extern.TextTrack) => track.active)
+    const tracks = player.getTextTracks()
+    const activeTrack = tracks.find(
+      (track: shaka.extern.TextTrack) => track.active
+    )
 
     store.setState(({ captions }) => {
       captions.activeTrack = activeTrack ?? null
-    })
-  }
-
-  const onTracksChanged = () => {
-    if (!player) {
-      return
-    }
-
-    store.setState(({ captions }) => {
-      captions.tracks = player.getTextTracks()
-    })
-  }
-
-  const onTextTrackVisibility = () => {
-    if (!player) {
-      return
-    }
-
-    store.setState(({ captions }) => {
-      captions.visible = player.isTextTrackVisible()
+      captions.tracks = tracks
+      captions.visible = Boolean(activeTrack)
     })
   }
 
@@ -148,17 +125,17 @@ function CaptionsSetup() {
     if (!mediaElement || !player) return
 
     if (canPlay) {
-      onTracksChanged()
+      syncTextTrackState()
     }
 
-    on(player, "textchanged", onTextTrackChanged)
-    on(player, ["trackschanged", "loading"], onTracksChanged)
-    on(player, "texttrackvisibility", onTextTrackVisibility)
+    on(player, ["textchanged", "trackschanged", "loading"], syncTextTrackState)
 
     return () => {
-      off(player, "textchanged", onTextTrackChanged)
-      off(player, ["trackschanged", "loading"], onTracksChanged)
-      off(player, "texttrackvisibility", onTextTrackVisibility)
+      off(
+        player,
+        ["textchanged", "trackschanged", "loading"],
+        syncTextTrackState
+      )
     }
   }, [canPlay, mediaElement, player])
 

--- a/apps/www/registry/default/hooks/use-player.ts
+++ b/apps/www/registry/default/hooks/use-player.ts
@@ -1,7 +1,8 @@
 "use client"
 
+import type shaka from "shaka-player"
+
 import React, { useRef } from "react"
-import shaka from "shaka-player"
 
 import type { PlaybackStore } from "@/registry/default/hooks/use-playback"
 import type {
@@ -64,12 +65,16 @@ export interface UsePlayerOptions<TAsset> {
 
 export const RECOMMENDED_PLAYER_BUFFERING_THROTTLE_MS = 250
 
+// Public Shaka error code. Keep this local so importing the hook on the server
+// does not evaluate Shaka's browser-only bundle during prerendering.
+const SHAKA_LOAD_INTERRUPTED_ERROR_CODE = 7000
+
 export function isLoadInterrupted(error: unknown): boolean {
   if (
     error &&
     typeof error === "object" &&
     "code" in error &&
-    (error as { code: number }).code === shaka.util.Error.Code.LOAD_INTERRUPTED
+    (error as { code: number }).code === SHAKA_LOAD_INTERRUPTED_ERROR_CODE
   ) {
     return true
   }

--- a/apps/www/registry/default/ui/error-screen.tsx
+++ b/apps/www/registry/default/ui/error-screen.tsx
@@ -3,7 +3,6 @@
 import type { ComponentPropsWithoutRef } from "react"
 
 import * as React from "react"
-import shaka from "shaka-player"
 
 import {
   Item,
@@ -189,11 +188,10 @@ export function isShakaError(error: unknown): error is ShakaErrorLike {
   }
 
   return (
-    error instanceof shaka.util.Error ||
-    (hasNumberProperty(error, "category") &&
-      hasNumberProperty(error, "code") &&
-      hasNumberProperty(error, "severity") &&
-      hasStringProperty(error, "message"))
+    hasNumberProperty(error, "category") &&
+    hasNumberProperty(error, "code") &&
+    hasNumberProperty(error, "severity") &&
+    hasStringProperty(error, "message")
   )
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "react-use": "^17.6.1",
         "remark-code-import": "^1.2.0",
         "remark-gfm": "^4.0.1",
-        "shaka-player": "^4.16.44",
+        "shaka-player": "^5.2.7",
         "three": "^0.185.1",
         "ts-morph": "28.0.0",
         "tw-animate-css": "^1.4.0",
@@ -1888,7 +1888,7 @@
 
     "shadcn": ["shadcn@4.18.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "kleur": "^4.1.5", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "socks": "^2.8.8", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "undici": "^7.27.2", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-tUFZgkYmfVNQVm3xX7lhSzOvDsp+O14ac5dwgXIr5mIsr79ISueb/Mu+ZtWMz0DH6v77u4eYyvbQ9TTMpSn3aw=="],
 
-    "shaka-player": ["shaka-player@4.16.44", "", {}, "sha512-t/eCE8IyrUes3xwdEL8U078PsRNEI+DhICcu5n7Laj5ycRe0QD3kDTWCaElTZxFQvA5dzjN8lKerNSyfWGPqVA=="],
+    "shaka-player": ["shaka-player@5.2.7", "", {}, "sha512-4qFQcLdAa0sHnTaXZ7dDLLh/X0TffX8BUoW6+eD4JFkUssGVhzNZsMfqNivDwIrzLTcXXZefvFNYJUUikXJDrg=="],
 
     "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,5 @@
 [install]
 minimumReleaseAge = 259200
 minimumReleaseAgeExcludes = [
-  "@types/node",
-  "@types/react",
-  "@types/react-dom",
-  "typescript",
+  "shaka-player",
 ]

--- a/prompts/code-rabbit.md
+++ b/prompts/code-rabbit.md
@@ -39,7 +39,7 @@ Flag PRs where:
 * Dependencies are incorrect
 * Public APIs are undocumented
 * Block files in `lib/`, `ui/`, `hooks/` folders have filenames matching any registry item in the dependency tree — the shadcn CLI rewrites those imports to the registry item's target path instead of the block's file. Use `components/` folder (always block-scoped) or a non-colliding filename.
-* Dependencies with breaking major versions are unpinned (e.g. `"shaka-player"` instead of `"shaka-player@^4"`)
+* Dependencies with breaking major versions are unpinned (e.g. `"shaka-player"` instead of `"shaka-player@^5.2.7"`)
 * Control primitives support `asChild` but not `render?: React.ReactElement` — the b0 shadcn preset transforms `asChild` to `render` at install time, so primitives must accept both
 
 ---

--- a/prompts/github-copilot.md
+++ b/prompts/github-copilot.md
@@ -55,7 +55,7 @@ Limeplay is a shadcn/ui-based, headless, composable media player UI library buil
 * ❌ Missing dependencies in registry metadata
 * ❌ CLI install must not break
 * ❌ Block files in `lib/`, `ui/`, `hooks/` whose filename (without extension) matches any registry item in the dependency tree (shadcn CLI hijacks the import) — use `components/` folder or a non-colliding name
-* ❌ Unpinned dependencies with breaking major versions (e.g. `"shaka-player"` instead of `"shaka-player@^4"`)
+* ❌ Unpinned dependencies with breaking major versions (e.g. `"shaka-player"` instead of `"shaka-player@^5.2.7"`)
 
 #### Imports
 

--- a/prompts/ide.md
+++ b/prompts/ide.md
@@ -195,8 +195,8 @@ The b0 shadcn preset uses Base UI instead of Radix. During `shadcn add`, the CLI
 #### Version Pinning
 
 Always pin dependencies that have breaking changes across majors:
-* ✅ `"shaka-player@^4"` — v5 removed APIs we use
-* ❌ `"shaka-player"` — installs latest (v5), breaks types
+* ✅ `"shaka-player@^5.2.7"` — pins the supported v5 release line
+* ❌ `"shaka-player"` — may install an unreviewed future major version
 
 #### Related upstream issues
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/WINOFFRG/limeplay/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caption track selection, visibility, and synchronization when enabling or disabling captions.
  * Improved compatibility with Shaka Player v5.2.7, including error detection and loading interruption handling.
  * Prevented unnecessary evaluation of browser-only player code during module loading.

* **Documentation**
  * Updated dependency guidance and registry examples to reference Shaka Player v5.2.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->